### PR TITLE
feat(standings): Implement league standings screen with navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,5 @@ profile.dSYM
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode
 
 # Secrets
-# Ignora os arquivos de configuração que contêm as chaves secretas.
 ArenaFC/Configs/Debug.xcconfig
 ArenaFC/Configs/Release.xcconfig

--- a/ArenaFC.xcodeproj/project.pbxproj
+++ b/ArenaFC.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		18BE03D32E7AD5A900036073 /* Exceptions for "ArenaFC" folder in "ArenaFC" target */ = {
+		18C06E7B2E7C09770044275E /* Exceptions for "ArenaFC" folder in "ArenaFC" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -43,7 +43,7 @@
 		18B15A332E7844B30023B0B3 /* ArenaFC */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				18BE03D32E7AD5A900036073 /* Exceptions for "ArenaFC" folder in "ArenaFC" target */,
+				18C06E7B2E7C09770044275E /* Exceptions for "ArenaFC" folder in "ArenaFC" target */,
 			);
 			path = ArenaFC;
 			sourceTree = "<group>";

--- a/ArenaFC.xcodeproj/xcuserdata/rudrigo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ArenaFC.xcodeproj/xcuserdata/rudrigo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,23 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>18B15A302E7844B30023B0B3</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>18B15A3F2E7844B50023B0B3</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>18B15A492E7844B50023B0B3</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/ArenaFC/Core/Networking/APIService.swift
+++ b/ArenaFC/Core/Networking/APIService.swift
@@ -8,21 +8,38 @@
 import Foundation
 
 final class APIService: APIServiceProtocol {
-
+    
     private let session: URLSession
     private let decoder: JSONDecoder
-
+    
     init(session: URLSession = .shared, decoder: JSONDecoder = JSONDecoder()) {
         self.session = session
         self.decoder = decoder
     }
-
+    
     func fetchLeagues() async throws -> [LeagueWrapper] {
+        let apiResponse: APIResponseLeagues = try await request(path: "/leagues")
+        return apiResponse.response
+    }
+    
+    func fetchStandings(for leagueId: Int, season: Int) async throws -> [Standing] {
+        let queryItems = [
+            URLQueryItem(name: "league", value: String(leagueId)),
+            URLQueryItem(name: "season", value: String(season))
+        ]
+        let apiResponse: APIResponseStandings = try await request(path: "/standings", queryItems: queryItems)
+        
+        let standings = apiResponse.response.first?.league.standings.first
+        return standings ?? []
+    }
+    
+    private func request<T: Decodable>(path: String, queryItems: [URLQueryItem]? = nil) async throws -> T {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "v3.football.api-sports.io"
-        components.path = "/leagues"
-
+        components.path = path
+        components.queryItems = queryItems
+        
         guard let url = components.url else {
             throw NetworkError.invalidURL
         }
@@ -35,21 +52,24 @@ final class APIService: APIServiceProtocol {
         
         request.addValue(apiKey, forHTTPHeaderField: "x-apisports-key")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
+        
         let (data, response) = try await session.data(for: request)
         
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NetworkError.invalidResponse
         }
-
+        
         guard (200...299).contains(httpResponse.statusCode) else {
             throw NetworkError.serverError(statusCode: httpResponse.statusCode)
         }
-
+        
         do {
-            let apiResponse = try decoder.decode(APIResponseLeagues.self, from: data)
-            return apiResponse.response
+            return try decoder.decode(T.self, from: data)
         } catch {
+            print("❌ DECODING ERROR for type \(T.self): \(error)")
+            if let decodingError = error as? DecodingError {
+                print("Decoding Error Details: \(decodingError)")
+            }
             throw NetworkError.decodingFailed(error)
         }
     }

--- a/ArenaFC/Core/Networking/APIService.swift
+++ b/ArenaFC/Core/Networking/APIService.swift
@@ -28,11 +28,16 @@ final class APIService: APIServiceProtocol {
         }
         
         var request = URLRequest(url: url)
-        let apiKey = APIConstants.apiKey 
+        
+        guard let apiKey = Bundle.main.infoDictionary?["API_KEY"] as? String, !apiKey.isEmpty else {
+            throw NetworkError.apiKeyNotFound
+        }
+        
         request.addValue(apiKey, forHTTPHeaderField: "x-apisports-key")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let (data, response) = try await session.data(for: request)
+        
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NetworkError.invalidResponse
         }

--- a/ArenaFC/Core/Networking/APIServiceProtocol.swift
+++ b/ArenaFC/Core/Networking/APIServiceProtocol.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 protocol APIServiceProtocol {
-
     func fetchLeagues() async throws -> [LeagueWrapper]
-
+    func fetchStandings(for leagueId: Int, season: Int) async throws -> [Standing]
 }

--- a/ArenaFC/Core/Networking/NetworkError.swift
+++ b/ArenaFC/Core/Networking/NetworkError.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum NetworkError: Error, CustomStringConvertible {
     case invalidURL
+    case apiKeyNotFound
     case requestFailed(Error)
     case invalidResponse
     case serverError(statusCode: Int)
@@ -18,6 +19,8 @@ enum NetworkError: Error, CustomStringConvertible {
         switch self {
         case .invalidURL:
             return "The provided URL is invalid."
+        case .apiKeyNotFound: 
+            return "API Key not found in Info.plist. Please check your configuration."
         case .requestFailed(let error):
             return "The request failed. Original error: \(error.localizedDescription)"
         case .invalidResponse:

--- a/ArenaFC/Features/Leagues/LeaguesView.swift
+++ b/ArenaFC/Features/Leagues/LeaguesView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 
 struct LeagueNavigationData: Hashable {
     let league: League
-    let seasonYear: Int
+    let currentSeasonYear: Int
+    let availableSeasons: [Season]
 }
 
 struct LeaguesView: View {
@@ -38,8 +39,7 @@ struct LeaguesView: View {
                             Text(league.name)
                                 .font(.headline)
                         }
-                        if let seasonYear = viewModel.findCurrentSeasonYear(for: league) {
-                            let navigationData = LeagueNavigationData(league: league, seasonYear: seasonYear)
+                        if let navigationData = viewModel.navigationData(for: league) {
                             NavigationLink(value: navigationData) {
                                 cellView
                             }
@@ -52,7 +52,7 @@ struct LeaguesView: View {
             }
             .navigationTitle("Leagues")
             .navigationDestination(for: LeagueNavigationData.self) { data in
-                Text("Standings for \(data.league.name) - Season \(data.seasonYear)")
+                Text("Standings for \(data.league.name) - Season \(data.currentSeasonYear)")
                     .navigationTitle(data.league.name)
             }
             .task {

--- a/ArenaFC/Features/Leagues/LeaguesView.swift
+++ b/ArenaFC/Features/Leagues/LeaguesView.swift
@@ -52,8 +52,7 @@ struct LeaguesView: View {
             }
             .navigationTitle("Leagues")
             .navigationDestination(for: LeagueNavigationData.self) { data in
-                Text("Standings for \(data.league.name) - Season \(data.currentSeasonYear)")
-                    .navigationTitle(data.league.name)
+                StandingsView(data: data)
             }
             .task {
                 await viewModel.fetchLeagues()

--- a/ArenaFC/Features/Leagues/LeaguesView.swift
+++ b/ArenaFC/Features/Leagues/LeaguesView.swift
@@ -12,7 +12,7 @@ struct LeaguesView: View {
     @StateObject private var viewModel = LeaguesViewModel()
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Group {
                 if viewModel.isLoading {
                     ProgressView("Loading Leagues...")
@@ -22,21 +22,27 @@ struct LeaguesView: View {
                         .padding()
                 } else {
                     List(viewModel.leagues) { league in
-                        HStack(spacing: 16) {
-                            AsyncImage(url: league.logo) { image in
-                                image.resizable()
-                            } placeholder: {
-                                ProgressView()
+                        NavigationLink(value: league) {
+                            HStack(spacing: 16) {
+                                AsyncImage(url: league.logo) { image in
+                                    image.resizable()
+                                } placeholder: {
+                                    ProgressView()
+                                }
+                                .frame(width: 40, height: 40)
+                                
+                                Text(league.name)
+                                    .font(.headline)
                             }
-                            .frame(width: 40, height: 40)
-                            
-                            Text(league.name)
-                                .font(.headline)
                         }
                     }
                 }
             }
-            .navigationTitle("Leagues")
+            .navigationTitle("Leagues") //
+            .navigationDestination(for: League.self) { league in
+                Text("Standings for \(league.name)")
+                    .navigationTitle(league.name)
+            }
             .task {
                 await viewModel.fetchLeagues()
             }

--- a/ArenaFC/Features/Leagues/LeaguesViewModel.swift
+++ b/ArenaFC/Features/Leagues/LeaguesViewModel.swift
@@ -41,13 +41,15 @@ final class LeaguesViewModel: ObservableObject {
         }
     }
     
-    func findCurrentSeasonYear(for league: League) -> Int? {
-        guard let wrapper = leagueWrappers.first(where: { $0.league.id == league.id }) else {
+    func navigationData(for league: League) -> LeagueNavigationData? {
+        guard let wrapper = leagueWrappers.first(where: { $0.league.id == league.id }),
+              !wrapper.seasons.isEmpty else {
             return nil
         }
         
-        let latestSeason = wrapper.seasons.sorted { $0.year > $1.year }.first
-        return latestSeason?.year
+        let sortedSeasons = wrapper.seasons.sorted { $0.year > $1.year }
+        guard let latestSeason = sortedSeasons.first else { return nil }
+        return LeagueNavigationData(league: league, currentSeasonYear: latestSeason.year, availableSeasons: sortedSeasons)
     }
     
 }

--- a/ArenaFC/Features/Leagues/LeaguesViewModel.swift
+++ b/ArenaFC/Features/Leagues/LeaguesViewModel.swift
@@ -9,33 +9,45 @@ import Foundation
 
 @MainActor
 final class LeaguesViewModel: ObservableObject {
-
+    
     @Published var leagues: [League] = []
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
-
-
+    
+    private var leagueWrappers: [LeagueWrapper] = []
     private let service: APIServiceProtocol
-
+    
     init(service: APIServiceProtocol = APIService()) {
         self.service = service
     }
-
+    
     func fetchLeagues() async {
         isLoading = true
         errorMessage = nil
-
+        
         defer {
             isLoading = false
         }
-
+        
         do {
-            let leagueWrappers = try await service.fetchLeagues()
-            self.leagues = leagueWrappers.map { $0.league }
+            let fetchedWrappers = try await service.fetchLeagues()
+            self.leagueWrappers = fetchedWrappers
+            self.leagues = fetchedWrappers.map { $0.league }
+            
         } catch let error as NetworkError {
             self.errorMessage = error.description
         } catch {
             self.errorMessage = error.localizedDescription
         }
     }
+    
+    func findCurrentSeasonYear(for league: League) -> Int? {
+        guard let wrapper = leagueWrappers.first(where: { $0.league.id == league.id }) else {
+            return nil
+        }
+        
+        let latestSeason = wrapper.seasons.sorted { $0.year > $1.year }.first
+        return latestSeason?.year
+    }
+    
 }

--- a/ArenaFC/Features/Standings/StandingsView.swift
+++ b/ArenaFC/Features/Standings/StandingsView.swift
@@ -1,0 +1,107 @@
+//
+//  StandingsView.swift
+//  ArenaFC
+//
+//  Created by Rodrigo Cerqueira Reis on 21/09/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct StandingsView: View {
+    @StateObject private var viewModel: StandingsViewModel
+
+    init(data: LeagueNavigationData) {
+        _viewModel = StateObject(wrappedValue: StandingsViewModel(data: data))
+    }
+    
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView("Loading Standings...")
+            } else if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .padding()
+            } else {
+                mainContentView
+            }
+        }
+        .navigationTitle(viewModel.league.name)
+        .task {
+            await viewModel.fetchStandings()
+        }
+    }
+    
+    private var mainContentView: some View {
+        List {
+            Section {
+                Picker("Season", selection: $viewModel.selectedSeasonYear) {
+                    ForEach(viewModel.availableSeasons) { season in
+                        Text(String(season.year)).tag(season.year)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+            
+            Section {
+                StandingsHeaderView()
+                
+                ForEach(viewModel.standings) { standing in
+                    StandingsRowView(standing: standing)
+                }
+            }
+        }
+        .onChange(of: viewModel.selectedSeasonYear) {
+            Task {
+                await viewModel.fetchStandings()
+            }
+        }
+    }
+}
+
+private struct StandingsRowView: View {
+    let standing: Standing
+    
+    var body: some View {
+        HStack {
+            Text("\(standing.rank)")
+                .frame(width: 30, alignment: .leading)
+            
+            AsyncImage(url: standing.team.logo) { image in
+                image.resizable()
+            } placeholder: {
+                ProgressView()
+            }
+            .frame(width: 25, height: 25)
+            
+            Text(standing.team.name)
+            
+            Spacer()
+            
+            Text("\(standing.all.played)").frame(width: 30)
+            Text("\(standing.points)").frame(width: 40)
+        }
+        .font(.system(size: 14))
+    }
+}
+
+private struct StandingsHeaderView: View {
+    var body: some View {
+        HStack {
+            Text("Pos")
+                .frame(width: 30, alignment: .leading)
+            
+            Spacer().frame(width: 25)
+            
+            Text("Club")
+            
+            Spacer()
+            
+            Text("P").frame(width: 30)
+            Text("Pts").frame(width: 40)
+        }
+        .font(.system(size: 12).bold())
+        .foregroundColor(.secondary)
+    }
+}

--- a/ArenaFC/Features/Standings/StandingsView.swift
+++ b/ArenaFC/Features/Standings/StandingsView.swift
@@ -38,7 +38,7 @@ struct StandingsView: View {
             Section {
                 Picker("Season", selection: $viewModel.selectedSeasonYear) {
                     ForEach(viewModel.availableSeasons) { season in
-                        Text(String(season.year)).tag(season.year)
+                        Text(season.seasonDisplay).tag(season.year)
                     }
                 }
                 .pickerStyle(.menu)

--- a/ArenaFC/Features/Standings/StandingsViewModel.swift
+++ b/ArenaFC/Features/Standings/StandingsViewModel.swift
@@ -9,16 +9,20 @@ import Foundation
 
 @MainActor
 final class StandingsViewModel: ObservableObject {
-
+    
     @Published var standings: [Standing] = []
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
+    @Published var selectedSeasonYear: Int
 
     let league: League
+    let availableSeasons: [Season]
     private let service: APIServiceProtocol
 
-    init(league: League, service: APIServiceProtocol = APIService()) {
-        self.league = league
+    init(data: LeagueNavigationData, service: APIServiceProtocol = APIService()) {
+        self.league = data.league
+        self.availableSeasons = data.availableSeasons
+        self.selectedSeasonYear = data.currentSeasonYear
         self.service = service
     }
 
@@ -31,8 +35,7 @@ final class StandingsViewModel: ObservableObject {
         }
 
         do {
-            let seasonYear = 2024
-            let fetchedStandings = try await service.fetchStandings(for: league.id, season: seasonYear)
+            let fetchedStandings = try await service.fetchStandings(for: league.id, season: selectedSeasonYear)
             self.standings = fetchedStandings
         } catch let error as NetworkError {
             self.errorMessage = error.description

--- a/ArenaFC/Features/Standings/StandingsViewModel.swift
+++ b/ArenaFC/Features/Standings/StandingsViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  StandingsViewModel.swift
+//  ArenaFC
+//
+//  Created by Rodrigo Cerqueira Reis on 18/09/25.
+//
+
+import Foundation
+
+@MainActor
+final class StandingsViewModel: ObservableObject {
+
+    @Published var standings: [Standing] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    let league: League
+    private let service: APIServiceProtocol
+
+    init(league: League, service: APIServiceProtocol = APIService()) {
+        self.league = league
+        self.service = service
+    }
+
+    func fetchStandings() async {
+        isLoading = true
+        errorMessage = nil
+        
+        defer {
+            isLoading = false
+        }
+
+        do {
+            let seasonYear = 2024
+            let fetchedStandings = try await service.fetchStandings(for: league.id, season: seasonYear)
+            self.standings = fetchedStandings
+        } catch let error as NetworkError {
+            self.errorMessage = error.description
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ArenaFC/Info.plist
+++ b/ArenaFC/Info.plist
@@ -2,8 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>API_KEY
-API_KEY</key>
+	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 </dict>
 </plist>

--- a/ArenaFC/Models/League.swift
+++ b/ArenaFC/Models/League.swift
@@ -17,7 +17,7 @@ struct LeagueWrapper: Decodable {
     let seasons: [Season]
 }
 
-struct League: Decodable, Identifiable, Equatable {
+struct League: Decodable, Identifiable, Equatable, Hashable {
     let id: Int
     let name: String
     let type: String?

--- a/ArenaFC/Models/League.swift
+++ b/ArenaFC/Models/League.swift
@@ -30,7 +30,7 @@ struct Country: Decodable, Equatable {
     let flag: URL?
 }
 
-struct Season: Decodable, Equatable {
+struct Season: Decodable, Equatable, Hashable {
     let year: Int
     let startDate: String?
     let endDate: String?

--- a/ArenaFC/Models/League.swift
+++ b/ArenaFC/Models/League.swift
@@ -30,11 +30,12 @@ struct Country: Decodable, Equatable {
     let flag: URL?
 }
 
-struct Season: Decodable, Equatable, Hashable {
+struct Season: Decodable, Equatable, Hashable, Identifiable {
     let year: Int
     let startDate: String?
     let endDate: String?
     let current: Bool
+    var id: Int { year }
 
     enum CodingKeys: String, CodingKey {
         case year

--- a/ArenaFC/Models/League.swift
+++ b/ArenaFC/Models/League.swift
@@ -36,6 +36,21 @@ struct Season: Decodable, Equatable, Hashable, Identifiable {
     let endDate: String?
     let current: Bool
     var id: Int { year }
+    
+    var seasonDisplay: String {
+           guard let startDate = startDate, let endDate = endDate else {
+               return String(year)
+           }
+           
+           let startYear = String(startDate.prefix(4))
+           let endYear = String(endDate.prefix(4))
+
+           if startYear != endYear {
+               return "\(startYear)/\(endYear.suffix(2))"
+           } else {
+               return startYear
+           }
+       }
 
     enum CodingKeys: String, CodingKey {
         case year

--- a/ArenaFC/Models/Team.swift
+++ b/ArenaFC/Models/Team.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Team: Decodable, Identifiable, Equatable {
+struct Team: Decodable, Identifiable, Equatable, Hashable {
     let id: Int
     let name: String
     let logo: URL


### PR DESCRIPTION
## 📝 Description

This Pull Request introduces a major new feature: the ability for users to navigate from the main leagues list to a detailed standings screen for a selected league.

This feature is fully dynamic, allowing the user to select different seasons and have the standings table update accordingly. It builds upon our existing data layer and implements a clean, state-driven navigation flow using modern SwiftUI APIs.

## 🛠️ Changes Implemented

#### Navigation
* Replaced the old `NavigationView` with the modern **`NavigationStack`** for more powerful and programmatic control.
* Implemented type-safe, state-driven navigation using `NavigationLink(value:)` and the `.navigationDestination(for:)` modifier.
* Created a `LeagueNavigationData` struct to safely pass rich context (league, available seasons, current season) from the source view to the destination.

#### Standings Screen (MVVM)
* **View (`StandingsView`):**
    * Built the complete UI to display the league standings in a clear, table-like format.
    * Included a `Picker` component to allow users to select from a list of available seasons.
    * Broke down the UI into smaller, reusable subviews (`StandingsRowView`, `StandingsHeaderView`) for better code organization, following SRP and Clean Code principles.
* **ViewModel (`StandingsViewModel`):**
    * Created a new ViewModel to manage the state and logic for the standings screen.
    * The ViewModel is initialized with the data passed from the `LeaguesView`.
    * It reactively fetches new data whenever the user's season selection changes, using the `.onChange` modifier in the View.

#### Enhancements
* **Networking Layer:** The `APIService` and its protocol were extended to support fetching the `/standings` endpoint. The service was also refactored to use a generic request helper, reducing code duplication.
* **Models:** The `Season` model was enhanced with a `seasonDisplay` computed property to provide user-friendly formatting (e.g., "2024/25"). Models were updated to conform to `Hashable` and `Identifiable` where needed for SwiftUI compatibility.

## ✅ How to Verify

1.  Check out the branch and run the app. The leagues list should load as before.
2.  Tap on a major league (e.g., "Premier League" or "La Liga").
3.  **Expected Result:** The app should navigate smoothly to a new screen. The screen's title should be the name of the league.
4.  The standings table for the most recent season should load and display.
5.  Interact with the "Season" picker at the top of the list.
6.  **Expected Result:** The table should show a loading indicator and then update with the standings for the newly selected season.