### PR TITLE
feat(roster): Implement team details screen and display player roster

### DIFF
--- a/ArenaFC/Core/Models/Player.swift
+++ b/ArenaFC/Core/Models/Player.swift
@@ -1,0 +1,29 @@
+//
+//  Player.swift
+//  ArenaFC
+//
+//  Created by Rodrigo Cerqueira Reis on 23/09/25.
+//
+
+import Foundation
+
+struct APIResponsePlayers: Decodable {
+    let response: [PlayerResponseWrapper]
+}
+
+struct PlayerResponseWrapper: Decodable {
+    let player: Player
+}
+
+struct Player: Decodable, Identifiable, Hashable {
+    let id: Int
+    let name: String?
+    let firstname: String?
+    let lastname: String?
+    let age: Int?
+    let nationality: String?
+    let height: String?
+    let weight: String?
+    let injured: Bool?
+    let photo: URL?
+}

--- a/ArenaFC/Core/Networking/APIService.swift
+++ b/ArenaFC/Core/Networking/APIService.swift
@@ -39,6 +39,16 @@ final class APIService: APIServiceProtocol {
         return apiResponse.response.first
     }
     
+    func fetchPlayers(for teamId: Int, season: Int) async throws -> [PlayerResponseWrapper] {
+        let queryItems = [
+            URLQueryItem(name: "team", value: String(teamId)),
+            URLQueryItem(name: "season", value: String(season))
+        ]
+        
+        let apiResponse: APIResponsePlayers = try await request(path: "/players", queryItems: queryItems)
+        return apiResponse.response
+    }
+    
     private func request<T: Decodable>(path: String, queryItems: [URLQueryItem]? = nil) async throws -> T {
         var components = URLComponents()
         components.scheme = "https"

--- a/ArenaFC/Core/Networking/APIServiceProtocol.swift
+++ b/ArenaFC/Core/Networking/APIServiceProtocol.swift
@@ -11,4 +11,5 @@ protocol APIServiceProtocol {
     func fetchLeagues() async throws -> [LeagueWrapper]
     func fetchStandings(for leagueId: Int, season: Int) async throws -> [Standing]
     func fetchTeamDetails(for teamId: Int) async throws -> TeamDetailsWrapper?
+    func fetchPlayers(for teamId: Int, season: Int) async throws -> [PlayerResponseWrapper]
 }

--- a/ArenaFC/Features/Standings/StandingsView.swift
+++ b/ArenaFC/Features/Standings/StandingsView.swift
@@ -55,7 +55,7 @@ struct StandingsView: View {
             }
         }
         .navigationDestination(for: Team.self) { team in
-            TeamDetailsView(teamId: team.id)
+            TeamDetailsView(teamId: team.id, seasonYear: viewModel.selectedSeasonYear)
         }
         .onChange(of: viewModel.selectedSeasonYear) {
             Task {

--- a/ArenaFC/Features/TeamDetails/TeamDetailsView.swift
+++ b/ArenaFC/Features/TeamDetails/TeamDetailsView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct TeamDetailsView: View {
     @StateObject private var viewModel: TeamDetailsViewModel
     
-    init(teamId: Int) {
-        _viewModel = StateObject(wrappedValue: TeamDetailsViewModel(teamId: teamId))
+    init(teamId: Int, seasonYear: Int) {
+        _viewModel = StateObject(wrappedValue: TeamDetailsViewModel(teamId: teamId, seasonYear: seasonYear))
     }
     
     var body: some View {

--- a/ArenaFC/Features/TeamDetails/TeamDetailsView.swift
+++ b/ArenaFC/Features/TeamDetails/TeamDetailsView.swift
@@ -30,7 +30,6 @@ struct TeamDetailsView: View {
         .task {
             await viewModel.fetchDetails()
         }
-        .navigationTitle(viewModel.teamDetails?.team.name ?? "Details")
     }
     
     private func contentView(for details: TeamDetailsWrapper) -> some View {
@@ -41,6 +40,8 @@ struct TeamDetailsView: View {
                 if let venue = details.venue {
                     venueView(for: venue)
                 }
+                
+                playerRosterView()
                 
                 Spacer()
             }
@@ -90,5 +91,61 @@ struct TeamDetailsView: View {
             Text("Stadium Information")
                 .font(.headline)
         }
+    }
+    
+    private func playerRosterView() -> some View {
+        Section {
+            if viewModel.isLoadingPlayers {
+                ProgressView()
+            } else if viewModel.players.isEmpty {
+                Text("Player roster not available for this season.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                LazyVStack(alignment: .leading) {
+                    ForEach(viewModel.players) { player in
+                        PlayerRowView(player: player)
+                        Divider()
+                    }
+                }
+            }
+        } header: {
+            Text("Player Roster")
+                .font(.title2.bold())
+                .padding(.bottom, 8)
+        }
+    }
+}
+
+private struct PlayerRowView: View {
+    let player: Player
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            AsyncImage(url: player.photo) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(Circle())
+            } placeholder: {
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .foregroundColor(.secondary.opacity(0.4))
+            }
+            .frame(width: 50, height: 50)
+            
+            VStack(alignment: .leading) {
+                Text(player.name ?? "Unknown Player")
+                    .font(.headline)
+                
+                let ageString = player.age.map { "Age: \($0)" } ?? "N/A"
+                let nationalityString = player.nationality ?? "Unknown"
+                Text("\(ageString) - \(nationalityString)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 8)
     }
 }

--- a/ArenaFC/Features/TeamDetails/TeamDetailsViewModel.swift
+++ b/ArenaFC/Features/TeamDetails/TeamDetailsViewModel.swift
@@ -9,17 +9,20 @@ import Foundation
 
 @MainActor
 final class TeamDetailsViewModel: ObservableObject {
-    
+
     @Published var teamDetails: TeamDetailsWrapper?
+    @Published var players: [Player] = []
     @Published var isLoading: Bool = false
+    @Published var isLoadingPlayers: Bool = false
     @Published var errorMessage: String?
     
-    
     private let teamId: Int
+    private let seasonYear: Int
     private let service: APIServiceProtocol
     
-    init(teamId: Int, service: APIServiceProtocol = APIService()) {
+    init(teamId: Int, seasonYear: Int, service: APIServiceProtocol = APIService()) {
         self.teamId = teamId
+        self.seasonYear = seasonYear
         self.service = service
     }
     
@@ -33,15 +36,32 @@ final class TeamDetailsViewModel: ObservableObject {
         
         do {
             let details = try await service.fetchTeamDetails(for: teamId)
-
+            
             if let details = details {
                 self.teamDetails = details
+                await fetchPlayers()
             } else {
                 self.errorMessage = "Team details not found."
             }
         } catch let error as NetworkError {
             self.errorMessage = error.description
         } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+    
+    private func fetchPlayers() async {
+        isLoadingPlayers = true
+        defer { isLoadingPlayers = false }
+        
+        do {
+            let playerWrappers = try await service.fetchPlayers(for: teamId, season: seasonYear)
+            self.players = playerWrappers.map { $0.player }
+        } catch let error as NetworkError {
+            print("Could not load players: \(error.description)")
+            self.errorMessage = error.description
+        } catch {
+            print("Could not load players: \(error.localizedDescription)")
             self.errorMessage = error.localizedDescription
         }
     }

--- a/ArenaFC/Features/TeamDetails/TeamDetailsViewModel.swift
+++ b/ArenaFC/Features/TeamDetails/TeamDetailsViewModel.swift
@@ -52,16 +52,17 @@ final class TeamDetailsViewModel: ObservableObject {
     
     private func fetchPlayers() async {
         isLoadingPlayers = true
-        defer { isLoadingPlayers = false }
         
+        defer {
+            isLoadingPlayers = false
+        }
+
         do {
             let playerWrappers = try await service.fetchPlayers(for: teamId, season: seasonYear)
             self.players = playerWrappers.map { $0.player }
         } catch let error as NetworkError {
-            print("Could not load players: \(error.description)")
             self.errorMessage = error.description
         } catch {
-            print("Could not load players: \(error.localizedDescription)")
             self.errorMessage = error.localizedDescription
         }
     }


### PR DESCRIPTION
## 📝 Description

This Pull Request introduces the complete feature for viewing a team's details and its player roster. This adds the third level of navigation to the application, allowing a user to drill down from a league's standings to a specific team.

The feature includes fetching two separate pieces of data sequentially (team details and then the player roster) to improve the user experience by showing primary content first.

## 🛠️ Changes Implemented

#### Navigation
* The `StandingsView` has been updated to wrap each team row in a `NavigationLink`.
* A new `.navigationDestination(for: Team.self)` modifier was added to handle routing to the new `TeamDetailsView`.

#### Team Details & Roster Screen (MVVM)
* **Models:**
    * Created new `Venue` and `Player` models to accurately represent the API data.
    * Expanded the `Team` model to include more detailed information.
    * Extensive use of optionals for defensive programming against incomplete API data.
* **Networking:**
    * The `APIService` and its protocol were extended with `fetchTeamDetails(for:)` and `fetchPlayers(for:season:)` functions.
* **ViewModel (`TeamDetailsViewModel`):**
    * Created a new ViewModel responsible for the sequential fetching logic: it first fetches the main team details, and upon success, triggers a secondary fetch for the player roster.
    * Manages separate loading states (`isLoading` and `isLoadingPlayers`) for a better UX.
* **View (`TeamDetailsView`):**
    * Built the complete UI to display team info, venue details, and the player roster.
    * The view is composed of smaller, single-responsibility subviews like `PlayerRowView` for better readability and maintenance.

## ✅ How to Verify

1.  Check out the `feature/player-roster` branch.
2.  Ensure the `Debug.xcconfig` file is set up with a valid API key.
3.  Build and run the app (`Cmd + R`).
4.  Navigate from the Leagues list -> Standings screen for a major league.
5.  Tap on any team row in the standings table.
6.  **Expected Result:** The app should navigate to a new screen. It will first load the main team/venue details. A loading indicator should then appear in the "Player Roster" section, followed by the list of players for that team and season.