### PR TITLE
test(team-details): Add unit tests for TeamDetailsViewModel

### DIFF
--- a/ArenaFCTests/Features/TeamDetails/TeamDetailsViewModelTests.swift
+++ b/ArenaFCTests/Features/TeamDetails/TeamDetailsViewModelTests.swift
@@ -1,0 +1,66 @@
+//
+//  TeamDetailsViewModelTests.swift
+//  ArenaFCTests
+//
+//  Created by Rodrigo Cerqueira Reis on 10/10/25.
+//
+
+import Foundation
+import XCTest
+@testable import ArenaFC
+
+@MainActor
+final class TeamDetailsViewModelTests: XCTestCase {
+
+    private var sut: TeamDetailsViewModel!
+    private var mockAPIService: MockAPIService!
+
+    override func setUp() {
+        super.setUp()
+        mockAPIService = MockAPIService()
+        sut = TeamDetailsViewModel(teamId: 1, seasonYear: 2024, service: mockAPIService)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockAPIService = nil
+        super.tearDown()
+    }
+
+    func test_fetchAllDetails_whenBothFetchesSucceed_shouldUpdateAllProperties() async {
+        let mockTeam = Team(id: 1, name: "Test Team", code: nil, country: nil, founded: nil, national: false, logo: URL(string: "a.com")!)
+        let mockVenue = Venue(id: 1, name: "Test Stadium", address: nil, city: nil, capacity: nil, surface: nil, image: nil)
+        mockAPIService.teamDetailsResult = .success(TeamDetailsWrapper(team: mockTeam, venue: mockVenue))
+        
+        let mockPlayer = Player(id: 1, name: "Test Player", firstname: nil, lastname: nil, age: nil, nationality: nil, height: nil, weight: nil, injured: false, photo: nil)
+        mockAPIService.playersResult = .success([PlayerResponseWrapper(player: mockPlayer)])
+        
+        await sut.fetchDetails()
+        
+        XCTAssertFalse(sut.isLoading, "Main loading should be false")
+        XCTAssertFalse(sut.isLoadingPlayers, "Players loading should be false")
+        XCTAssertNotNil(sut.teamDetails, "Team details should be populated")
+        XCTAssertEqual(sut.teamDetails?.team.name, "Test Team")
+        XCTAssertEqual(sut.players.count, 1, "Players array should contain one player")
+        XCTAssertEqual(sut.players.first?.name, "Test Player")
+        XCTAssertNil(sut.errorMessage, "Error message should be nil on success")
+    }
+    
+        func test_fetchAllDetails_whenPlayerFetchFails_shouldPopulateTeamDetailsAndUpdateErrorMessage() async {
+            let mockTeam = Team(id: 1, name: "Test Team", code: nil, country: nil, founded: nil, national: false, logo: URL(string: "a.com")!)
+            let mockVenue = Venue(id: 1, name: "Test Stadium", address: nil, city: nil, capacity: nil, surface: nil, image: nil)
+            mockAPIService.teamDetailsResult = .success(TeamDetailsWrapper(team: mockTeam, venue: mockVenue))
+            
+            let expectedError = NetworkError.serverError(statusCode: 500)
+            mockAPIService.playersResult = .failure(expectedError)
+            
+            await sut.fetchDetails()
+            
+            XCTAssertNotNil(sut.teamDetails, "Team details should still be populated even if players fetch fails")
+            XCTAssertEqual(sut.teamDetails?.team.name, "Test Team")
+            
+            XCTAssertTrue(sut.players.isEmpty, "Players array should be empty on failure")
+            XCTAssertNotNil(sut.errorMessage, "Error message should not be nil when players fetch fails")
+            XCTAssertEqual(sut.errorMessage, expectedError.description)
+        }
+}

--- a/ArenaFCTests/Mocks/MockAPIService.swift
+++ b/ArenaFCTests/Mocks/MockAPIService.swift
@@ -13,13 +13,15 @@ final class MockAPIService: APIServiceProtocol {
     var leaguesResult: Result<[LeagueWrapper], NetworkError>?
     var standingsResult: Result<[Standing], NetworkError>?
     
+    var teamDetailsResult: Result<TeamDetailsWrapper?, NetworkError>?
+    var playersResult: Result<[PlayerResponseWrapper], NetworkError>?
+    
+    
     func fetchLeagues() async throws -> [LeagueWrapper] {
         if let result = leaguesResult {
             switch result {
-            case .success(let wrappers):
-                return wrappers
-            case .failure(let error):
-                throw error
+            case .success(let wrappers): return wrappers
+            case .failure(let error): throw error
             }
         }
         fatalError("You must set a result for fetchLeagues before calling it.")
@@ -28,15 +30,30 @@ final class MockAPIService: APIServiceProtocol {
     func fetchStandings(for leagueId: Int, season: Int) async throws -> [Standing] {
         if let result = standingsResult {
             switch result {
-            case .success(let standings):
-                return standings
-            case .failure(let error):
-                throw error
+            case .success(let standings): return standings
+            case .failure(let error): throw error
             }
         }
         fatalError("You must set a result for fetchStandings before calling it.")
     }
     
-    func fetchTeamDetails(for teamId: Int) async throws -> TeamDetailsWrapper? { nil }
-    func fetchPlayers(for teamId: Int, season: Int) async throws -> [PlayerResponseWrapper] { [] }
+    func fetchTeamDetails(for teamId: Int) async throws -> TeamDetailsWrapper? {
+        if let result = teamDetailsResult {
+            switch result {
+            case .success(let details): return details
+            case .failure(let error): throw error
+            }
+        }
+        fatalError("You must set a result for fetchTeamDetails before calling it.")
+    }
+    
+    func fetchPlayers(for teamId: Int, season: Int) async throws -> [PlayerResponseWrapper] {
+        if let result = playersResult {
+            switch result {
+            case .success(let players): return players
+            case .failure(let error): throw error
+            }
+        }
+        fatalError("You must set a result for fetchPlayers before calling it.")
+    }
 }


### PR DESCRIPTION
## 📝 Description

This Pull Request adds a comprehensive suite of unit tests for the `TeamDetailsViewModel`. This is a crucial test suite as this ViewModel contains our most complex business logic so far: a sequential, multi-step data fetch.

The tests ensure that the ViewModel correctly manages its state throughout this flow, including handling partial failures where one network call succeeds but the subsequent one fails.

## 🛠️ Changes Implemented

* **`MockAPIService` Extended:**
    * The mock service was finalized to implement all functions from the `APIServiceProtocol`, including `fetchTeamDetails(for:)` and `fetchPlayers(for:season:)`.
    * This allows us to simulate success or failure for each of the sequential network calls independently.

* **`TeamDetailsViewModelTests` Suite:**
    * A new XCTestCase class was created and configured with the required dependencies (`teamId`, `seasonYear`) in the `setUp()` method.
    * **Full Success Scenario:** A test was added to verify that when *both* `fetchTeamDetails` and `fetchPlayers` succeed, all properties (`teamDetails`, `players`) are correctly populated and loading states are cleared.
    * **Partial Failure Scenario:** A second, critical test was added to verify robustness. It simulates a successful `fetchTeamDetails` call followed by a failed `fetchPlayers` call. The test asserts that the `teamDetails` data is *preserved* (not lost) and that the `errorMessage` is correctly set from the second call.

## ✅ How to Verify

1.  Check out the branch.
2.  Open the project in Xcode and navigate to the Test Navigator (the diamond icon 💎 on the left sidebar).
3.  Find the `TeamDetailsViewModelTests` and run all tests for this class.
4.  **Expected Result:** All tests in the suite should pass quickly and display a green checkmark ✅.